### PR TITLE
chore: add support for linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*.pconf linguist-language=Starlark
+*.mpconf linguist-language=Starlark
+*.pinc linguist-language=Starlark
+*.materialized_JSON linguist-generated


### PR DESCRIPTION
Should fix starlark syntax highlighting on Github and treat `materialized_JSON` as generated code